### PR TITLE
Switch to poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools >= 35.0.2", "wheel >= 0.29.0", "poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["setuptools >= 35.0.2", "wheel >= 0.29.0", "poetry_core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "pyairnow"


### PR DESCRIPTION
`poetry-core` intended to be a light weight, fully compliant, self-contained package allowing PEP 517 compatible build frontends to build Poetry managed projects.