### PR TITLE
Add py.typed marker (PEP-561)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,3 +37,9 @@ flake8 = "^3.8.3"
 pytest = "^6.0.2"
 pytest-asyncio = "^0.14.0"
 pytest-cov = "^2.10.1"
+
+[tool.setuptools.package-data]
+"pyairnow" = ["py.typed"]
+
+[tool.setuptools.packages.find]
+where = ["pyairnow"]


### PR DESCRIPTION
Without a py.typed marker, `mypy` and other type-checkers are unable to use the provided type-hints - instead, they return errors like the following mypy example when run with strict enough settings
```
path/to/file.py:1: error: Skipping analyzing "pyairnow.errors": module is installed, but missing
library stubs or py.typed marker  [import-untyped]
    from pyairnow.errors import EmptyResponseError
```

This change adds the required marker file and ensures it's built into the final build artifact.