### PR TITLE
Update conv.py to accomodate revised EPA guidance from May 2024.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ asyncio.run(main())
 
 The library provides two convenience functions to convert between AQI and
 pollutant concentrations. See
-[this EPA document](https://www.airnow.gov/sites/default/files/2020-05/aqi-technical-assistance-document-sept2018.pdf)
+[this EPA document](https://document.airnow.gov/technical-assistance-document-for-the-reporting-of-daily-air-quailty.pdf)
 for more details.
 
 ```python

--- a/tests/test_14_conversions.py
+++ b/tests/test_14_conversions.py
@@ -5,17 +5,21 @@ from pyairnow.conv import aqi_to_concentration, concentration_to_aqi
 
 def test_convert_pm25():
     assert aqi_to_concentration(0, 'PM2.5') == 0
-    assert aqi_to_concentration(25, 'PM2.5') == 6
-    assert aqi_to_concentration(50, 'PM2.5') == 12
-    assert aqi_to_concentration(51, 'PM2.5') == 12.1
-    assert aqi_to_concentration(86, 'PM2.5') == 28.7
+    assert aqi_to_concentration(25, 'PM2.5') == 4.5
+    assert aqi_to_concentration(50, 'PM2.5') == 9.0
+    assert aqi_to_concentration(51, 'PM2.5') == 9.1
+    assert aqi_to_concentration(86, 'PM2.5') == 27.9
     assert aqi_to_concentration(144, 'PM2.5') == 53.0
+    assert aqi_to_concentration(500, 'PM2.5') == 325.4
+    assert aqi_to_concentration(501, 'PM2.5') == 325.9
 
     assert concentration_to_aqi(0, 'PM2.5') == 0
-    assert concentration_to_aqi(12.0, 'PM2.5') == 50
-    assert concentration_to_aqi(12.1, 'PM2.5') == 51
-    assert concentration_to_aqi(28.66, 'PM2.5') == 86
+    assert concentration_to_aqi(9.0, 'PM2.5') == 50
+    assert concentration_to_aqi(9.1, 'PM2.5') == 51
+    assert concentration_to_aqi(27.9, 'PM2.5') == 86
     assert concentration_to_aqi(53.0, 'PM2.5') == 144
+    assert concentration_to_aqi(325.4, 'PM2.5') == 500
+    assert concentration_to_aqi(325.9, 'PM2.5') == 501
 
 
 def test_convert_invalid_negative_aqi():
@@ -23,16 +27,6 @@ def test_convert_invalid_negative_aqi():
         aqi_to_concentration(-1, 'PM2.5')
 
 
-def test_convert_invalid_overrange_aqi():
-    with pytest.raises(ValueError):
-        aqi_to_concentration(501, 'PM2.5')
-
-
 def test_convert_invalid_negative_o3():
     with pytest.raises(ValueError):
         concentration_to_aqi(-0.0008, 'O3')
-
-
-def test_convert_invalid_overrange_o3():
-    with pytest.raises(ValueError):
-        concentration_to_aqi(0.605, 'O3')


### PR DESCRIPTION
Update pollutant concentration breakpoint data and conversion functions to meet updated EPA guidance May 2024, found in their revised [Technical Assistance Document](https://document.airnow.gov/technical-assistance-document-for-the-reporting-of-daily-air-quailty.pdf).

- PM2.5 breakpoints changed.
- Breakpoints for AQIs > 300 (hazardous) removed.
- Conversions for over-range AQI and concentration values are now allowed, using the same equation(s) and the data from the highest AQI category.
   - AirNow API is returning AQI values > 500 at least some of the time, as per [home-assistant/core/issues/140622](https://github.com/home-assistant/core/issues/140622)