### PR TITLE
Migrate to AirNow 2026 API endpoints

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,15 +17,14 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
           - "3.13"
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
@@ -40,8 +39,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
           architecture: x64
@@ -51,7 +50,7 @@ jobs:
           .venv/bin/pip install -r requirements-dev.txt
           .venv/bin/python -m pytest --cov-report=xml --cov=pyairnow tests/
 
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -60,8 +59,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
           architecture: x64

--- a/pyairnow/api.py
+++ b/pyairnow/api.py
@@ -16,14 +16,15 @@ API_DEFAULT_TIMEOUT: int = 10
 class WebServiceAPI:
     '''Client to interact with AirNow API'''
     def __init__(
-        self, api_key: str, *, session: Optional[ClientSession] = None
+        self, api_key: str, *, session: Optional[ClientSession] = None,
+        legacy_format: bool = True
     ) -> None:
         '''Initialize with Client Session and API Key'''
         self._api_key: Optional[str] = api_key
         self._session: Optional[ClientSession] = session
 
-        self.forecast = Forecast(self._get)
-        self.observations = Observations(self._get)
+        self.forecast = Forecast(self._get, legacy_format=legacy_format)
+        self.observations = Observations(self._get, legacy_format=legacy_format)
 
     async def _get(
         self, endpoint: str, *, base_url: str = API_BASE_URL, **kwargs

--- a/pyairnow/forecast.py
+++ b/pyairnow/forecast.py
@@ -3,6 +3,37 @@ from datetime import date as date_, datetime
 from typing import Callable, Coroutine, Optional, Union
 
 
+PARAMETER_NAME_MAP = {
+    'OZONE': 'O3',
+}
+
+
+def _normalize_forecast(raw: dict) -> dict:
+    '''Transform new API response format to legacy format for compatibility.'''
+    cat_number = raw.get('categoryNumber', raw.get('Category', {}).get('Number', 0))
+    cat_name = raw.get('categoryName', raw.get('Category', {}).get('Name', ''))
+
+    param = raw.get('parameterName', raw.get('ParameterName', ''))
+    param = PARAMETER_NAME_MAP.get(param, param)
+
+    return {
+        'DateIssue': raw.get('dateIssue', ''),
+        'DateForecast': raw.get('dateValid', raw.get('DateForecast', '')),
+        'ReportingArea': raw.get('reportingArea', raw.get('ReportingArea', '')),
+        'StateCode': raw.get('stateCode', raw.get('StateCode', '')),
+        'Latitude': raw.get('latitude', raw.get('Latitude')),
+        'Longitude': raw.get('longitude', raw.get('Longitude')),
+        'ParameterName': param,
+        'AQI': raw.get('aqi', raw.get('AQI', -1)),
+        'Category': {
+            'Number': cat_number,
+            'Name': cat_name,
+        },
+        'ActionDay': raw.get('actionDay', raw.get('ActionDay', False)),
+        'Discussion': raw.get('discussion', raw.get('Discussion', '')),
+    }
+
+
 class Forecast:
     '''
     Class to retrieve the air quality forecast by zip code or by latitude and
@@ -18,7 +49,7 @@ class Forecast:
         date: Optional[Union[date_, datetime, str]] = None,
         distance: Optional[int] = None
     ) -> list:
-        '''Request current observation for zip code'''
+        '''Request forecast for zip code'''
         params: dict = dict(zipCode=zipCode)
         if date and isinstance(date, str):
             y, m, d = date.split('-')
@@ -30,10 +61,11 @@ class Forecast:
         if distance:
             params['distance'] = distance
 
-        return await self._request(
-            'aq/forecast/zipCode',
+        data = await self._request(
+            'aq/forecast/current',
             params=params
         )
+        return [_normalize_forecast(f) for f in data]
 
     async def latLong(
         self,
@@ -42,8 +74,8 @@ class Forecast:
         *,
         date: Optional[Union[date_, datetime, str]] = None,
         distance: Optional[int] = None,
-    ) -> None:
-        '''Request current observation for latitude/longitude'''
+    ) -> list:
+        '''Request forecast for latitude/longitude'''
         params: dict = dict(
             latitude=str(latitude),
             longitude=str(longitude),
@@ -58,7 +90,8 @@ class Forecast:
         if distance:
             params['distance'] = distance
 
-        return await self._request(
-            'aq/forecast/latLong',
+        data = await self._request(
+            'aq/forecast/current',
             params=params
         )
+        return [_normalize_forecast(f) for f in data]

--- a/pyairnow/forecast.py
+++ b/pyairnow/forecast.py
@@ -1,4 +1,5 @@
 '''Retrieve Air Quality Forecasts'''
+import warnings
 from datetime import date as date_, datetime
 from typing import Callable, Coroutine, Optional, Union
 
@@ -39,8 +40,12 @@ class Forecast:
     Class to retrieve the air quality forecast by zip code or by latitude and
     longitude.
     '''
-    def __init__(self, request: Callable[..., Coroutine]) -> None:
+    def __init__(
+        self, request: Callable[..., Coroutine], *,
+        legacy_format: bool = True
+    ) -> None:
         self._request = request
+        self._legacy_format = legacy_format
 
     async def zipCode(
         self,
@@ -58,14 +63,21 @@ class Forecast:
             params['date'] = date.date().isoformat()
         elif date and isinstance(date, date_):
             params['date'] = date.isoformat()
-        if distance:
-            params['distance'] = distance
+        if distance is not None:
+            warnings.warn(
+                'The distance parameter is deprecated and ignored by the '
+                'AirNow 2026 API. It will be removed in a future version.',
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         data = await self._request(
             'aq/forecast/current',
             params=params
         )
-        return [_normalize_forecast(f) for f in data]
+        if self._legacy_format:
+            return [_normalize_forecast(f) for f in data]
+        return data
 
     async def latLong(
         self,
@@ -87,11 +99,18 @@ class Forecast:
             params['date'] = date.date().isoformat()
         elif date and isinstance(date, date_):
             params['date'] = date.isoformat()
-        if distance:
-            params['distance'] = distance
+        if distance is not None:
+            warnings.warn(
+                'The distance parameter is deprecated and ignored by the '
+                'AirNow 2026 API. It will be removed in a future version.',
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         data = await self._request(
             'aq/forecast/current',
             params=params
         )
-        return [_normalize_forecast(f) for f in data]
+        if self._legacy_format:
+            return [_normalize_forecast(f) for f in data]
+        return data

--- a/pyairnow/observation.py
+++ b/pyairnow/observation.py
@@ -2,6 +2,52 @@
 from typing import Callable, Coroutine, Optional, Union
 
 
+CATEGORY_NAME_TO_NUMBER = {
+    'Good': 1,
+    'Moderate': 2,
+    'Unhealthy for Sensitive Groups': 3,
+    'Unhealthy': 4,
+    'Very Unhealthy': 5,
+    'Hazardous': 6,
+}
+
+
+PARAMETER_NAME_MAP = {
+    'OZONE': 'O3',
+}
+
+
+def _normalize_observation(raw: dict) -> dict:
+    '''Transform new API response format to legacy format for compatibility.'''
+    hour_raw = raw.get('hourObserved', 0)
+    if isinstance(hour_raw, str):
+        hour = int(hour_raw.split(':')[0])
+    else:
+        hour = int(hour_raw)
+
+    cat_name = raw.get('aqiCategoryName', '')
+    cat_number = CATEGORY_NAME_TO_NUMBER.get(cat_name, 0)
+
+    param = raw.get('parameterName', '')
+    param = PARAMETER_NAME_MAP.get(param, param)
+
+    return {
+        'DateObserved': raw.get('dateObserved', ''),
+        'HourObserved': hour,
+        'LocalTimeZone': raw.get('localTimeZone', ''),
+        'ReportingArea': raw.get('reportingAreaName', ''),
+        'StateCode': raw.get('stateCode', ''),
+        'Latitude': raw.get('latitude'),
+        'Longitude': raw.get('longitude'),
+        'ParameterName': param,
+        'AQI': raw.get('nowcastAQI', raw.get('aqi', -1)),
+        'Category': {
+            'Number': cat_number,
+            'Name': cat_name,
+        },
+    }
+
+
 class Observations:
     '''
     Class to retrieve the current air quality observations by zip code or by
@@ -21,10 +67,11 @@ class Observations:
         if distance:
             params['distance'] = distance
 
-        return await self._request(
-            'aq/observation/zipCode/current',
+        data = await self._request(
+            'aq/observation/current/ziplatlong',
             params=params
         )
+        return [_normalize_observation(o) for o in data]
 
     async def latLong(
         self,
@@ -41,7 +88,8 @@ class Observations:
         if distance:
             params['distance'] = distance
 
-        return await self._request(
-            'aq/observation/latLong/current',
+        data = await self._request(
+            'aq/observation/current/ziplatlong',
             params=params
         )
+        return [_normalize_observation(o) for o in data]

--- a/pyairnow/observation.py
+++ b/pyairnow/observation.py
@@ -1,4 +1,5 @@
 '''Retrieve a list of Current Observations'''
+import warnings
 from typing import Callable, Coroutine, Optional, Union
 
 
@@ -53,8 +54,12 @@ class Observations:
     Class to retrieve the current air quality observations by zip code or by
     latitude and longitude.
     '''
-    def __init__(self, request: Callable[..., Coroutine]) -> None:
+    def __init__(
+        self, request: Callable[..., Coroutine], *,
+        legacy_format: bool = True
+    ) -> None:
         self._request = request
+        self._legacy_format = legacy_format
 
     async def zipCode(
         self,
@@ -64,14 +69,21 @@ class Observations:
     ) -> list:
         '''Request current observation for zip code'''
         params: dict = dict(zipCode=zipCode)
-        if distance:
-            params['distance'] = distance
+        if distance is not None:
+            warnings.warn(
+                'The distance parameter is deprecated and ignored by the '
+                'AirNow 2026 API. It will be removed in a future version.',
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         data = await self._request(
             'aq/observation/current/ziplatlong',
             params=params
         )
-        return [_normalize_observation(o) for o in data]
+        if self._legacy_format:
+            return [_normalize_observation(o) for o in data]
+        return data
 
     async def latLong(
         self,
@@ -85,11 +97,18 @@ class Observations:
             latitude=str(latitude),
             longitude=str(longitude),
         )
-        if distance:
-            params['distance'] = distance
+        if distance is not None:
+            warnings.warn(
+                'The distance parameter is deprecated and ignored by the '
+                'AirNow 2026 API. It will be removed in a future version.',
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         data = await self._request(
             'aq/observation/current/ziplatlong',
             params=params
         )
-        return [_normalize_observation(o) for o in data]
+        if self._legacy_format:
+            return [_normalize_observation(o) for o in data]
+        return data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ classifiers = [
   "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -29,7 +28,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 aiohttp = "^3.10.0"
-python = "^3.9"
+python = "^3.10"
 
 [tool.poetry.group.dev.dependencies]
 aioresponses = "^0.7.8"

--- a/tests/mock_api.py
+++ b/tests/mock_api.py
@@ -4,24 +4,79 @@ import re
 from aioresponses import CallbackResult
 
 MOCK_API_KEY = '01234567-89AB-CDEF-0123-456789ABCDEF'
-RE_ENDPOINTS = re.compile(
-    '^/?aq/(forecast|observation)/(zipCode|latLong)(/(current))?/?$'
-)
+
+RE_FORECAST_CURRENT = re.compile(r'^/?aq/forecast/current/?$')
+RE_OBS_ZIPLATLONG = re.compile(r'^/?aq/observation/current/ziplatlong/?$')
+
+MOCK_OBSERVATION_RESPONSE = [
+    {
+        'dateObserved': '2020-09-01',
+        'hourObserved': '15:00',
+        'localTimeZone': 'PDT',
+        'reportingAreaName': 'Los Angeles',
+        'siteID': '060371103',
+        'siteName': 'Los Angeles - N Main',
+        'parameterName': 'PM2.5',
+        'nowcastAQI': 55,
+        'aqiCategoryName': 'Moderate',
+        'reportingAgency': 'South Coast AQMD',
+        'lookupBehavior': 'Closest Reading By Pollutant',
+        'consideredMonitors': 'All',
+        'lookupBoundary': '25 Miles',
+    },
+    {
+        'dateObserved': '2020-09-01',
+        'hourObserved': '15:00',
+        'localTimeZone': 'PDT',
+        'reportingAreaName': 'Los Angeles',
+        'siteID': '060371103',
+        'siteName': 'Los Angeles - N Main',
+        'parameterName': 'OZONE',
+        'nowcastAQI': 42,
+        'aqiCategoryName': 'Good',
+        'reportingAgency': 'South Coast AQMD',
+        'lookupBehavior': 'Closest Reading By Pollutant',
+        'consideredMonitors': 'All',
+        'lookupBoundary': '25 Miles',
+    },
+]
+
+MOCK_FORECAST_RESPONSE = [
+    {
+        'dateIssue': '2020-09-01',
+        'dateValid': '2020-09-02',
+        'reportingArea': 'Los Angeles',
+        'reportingAreaCode': 'ca060',
+        'stateCode': 'CA',
+        'parameterName': 'OZONE',
+        'aqi': 55,
+        'forecastAgency': 'South Coast AQMD',
+        'categoryNumber': 2,
+        'categoryName': 'Moderate',
+        'actionDay': False,
+        'discussion': '',
+    },
+    {
+        'dateIssue': '2020-09-01',
+        'dateValid': '2020-09-02',
+        'reportingArea': 'Los Angeles',
+        'reportingAreaCode': 'ca060',
+        'stateCode': 'CA',
+        'parameterName': 'PM2.5',
+        'aqi': 42,
+        'forecastAgency': 'South Coast AQMD',
+        'categoryNumber': 1,
+        'categoryName': 'Good',
+        'actionDay': False,
+        'discussion': '',
+    },
+]
 
 
 def mock_airnow_api(url, **kwargs):
     '''
     Mock the AirNow API
     '''
-    m = RE_ENDPOINTS.match(url.path)
-    if m is None:
-        return CallbackResult(status=404)
-
-    # Parse URL path
-    ep_type = m.group(1)
-    ep_mode = m.group(2)
-    ep_when = m.group(4)
-
     # Check API Key
     if 'API_KEY' not in url.query:
         return CallbackResult(status=401, payload=dict(
@@ -78,11 +133,11 @@ def mock_airnow_api(url, **kwargs):
     if 'zipCode' in url.query and url.query['zipCode'] == 'dict':
         return CallbackResult(payload=dict(status='OK'))
 
-    # Return JSON with the endpoint and query information
-    payload = dict(
-        type=ep_type,
-        mode=ep_mode,
-        when=ep_when,
-        query=dict(url.query),
-    )
-    return CallbackResult(payload=[payload])
+    # Route to appropriate mock response
+    if RE_OBS_ZIPLATLONG.match(url.path):
+        return CallbackResult(payload=MOCK_OBSERVATION_RESPONSE)
+
+    if RE_FORECAST_CURRENT.match(url.path):
+        return CallbackResult(payload=MOCK_FORECAST_RESPONSE)
+
+    return CallbackResult(status=404)

--- a/tests/test_10_api.py
+++ b/tests/test_10_api.py
@@ -12,14 +12,12 @@ async def test_api(mock_airnowapi):
     data = await client.forecast.zipCode('90001')
 
     assert isinstance(data, list)
-    assert len(data) == 1
+    assert len(data) == 2
 
-    assert data[0]['type'] == 'forecast'
-    assert data[0]['mode'] == 'zipCode'
-    assert data[0]['when'] is None
-
-    assert 'zipCode' in data[0]['query']
-    assert data[0]['query']['zipCode'] == '90001'
+    assert data[0]['ParameterName'] == 'O3'
+    assert data[0]['AQI'] == 55
+    assert data[0]['Category']['Number'] == 2
+    assert data[0]['Category']['Name'] == 'Moderate'
 
 
 @pytest.mark.asyncio
@@ -29,11 +27,9 @@ async def test_api_with_session(mock_airnowapi):
     data = await client.forecast.zipCode(90001)
 
     assert isinstance(data, list)
-    assert len(data) == 1
+    assert len(data) == 2
 
-    assert data[0]['type'] == 'forecast'
-    assert data[0]['mode'] == 'zipCode'
-    assert data[0]['when'] is None
+    assert data[0]['ParameterName'] == 'O3'
+    assert data[0]['AQI'] == 55
 
-    assert 'zipCode' in data[0]['query']
-    assert data[0]['query']['zipCode'] == '90001'
+    await session.close()

--- a/tests/test_12_forecast.py
+++ b/tests/test_12_forecast.py
@@ -31,7 +31,8 @@ async def test_api_forecast_zipcode(mock_airnowapi):
 @pytest.mark.asyncio
 async def test_api_forecast_zipcode_distance(mock_airnowapi):
     client = WebServiceAPI(MOCK_API_KEY)
-    data = await client.forecast.zipCode(90001, distance=100)
+    with pytest.warns(DeprecationWarning, match='distance parameter is deprecated'):
+        data = await client.forecast.zipCode(90001, distance=100)
 
     assert isinstance(data, list)
     assert len(data) == 2
@@ -91,10 +92,11 @@ async def test_api_forecast_ll(mock_airnowapi):
 @pytest.mark.asyncio
 async def test_api_forecast_ll_distance(mock_airnowapi):
     client = WebServiceAPI(MOCK_API_KEY)
-    data = await client.forecast.latLong(
-        34.053718, -118.244842,
-        distance=120
-    )
+    with pytest.warns(DeprecationWarning, match='distance parameter is deprecated'):
+        data = await client.forecast.latLong(
+            34.053718, -118.244842,
+            distance=120
+        )
 
     assert isinstance(data, list)
     assert len(data) == 2
@@ -134,3 +136,28 @@ async def test_api_forecast_ll_date_datetime(mock_airnowapi):
 
     assert isinstance(data, list)
     assert len(data) == 2
+
+
+@pytest.mark.asyncio
+async def test_api_forecast_zipcode_raw_format(mock_airnowapi):
+    client = WebServiceAPI(MOCK_API_KEY, legacy_format=False)
+    data = await client.forecast.zipCode(90001)
+
+    assert isinstance(data, list)
+    assert len(data) == 2
+    assert data[0]['parameterName'] == 'OZONE'
+    assert data[0]['aqi'] == 55
+    assert data[0]['categoryName'] == 'Moderate'
+    assert 'DateIssue' not in data[0]
+
+
+@pytest.mark.asyncio
+async def test_api_forecast_ll_raw_format(mock_airnowapi):
+    client = WebServiceAPI(MOCK_API_KEY, legacy_format=False)
+    data = await client.forecast.latLong(34.053718, -118.244842)
+
+    assert isinstance(data, list)
+    assert len(data) == 2
+    assert data[0]['parameterName'] == 'OZONE'
+    assert data[0]['aqi'] == 55
+    assert 'DateIssue' not in data[0]

--- a/tests/test_12_forecast.py
+++ b/tests/test_12_forecast.py
@@ -12,14 +12,20 @@ async def test_api_forecast_zipcode(mock_airnowapi):
     data = await client.forecast.zipCode(90001)
 
     assert isinstance(data, list)
-    assert len(data) == 1
+    assert len(data) == 2
 
-    assert data[0]['type'] == 'forecast'
-    assert data[0]['mode'] == 'zipCode'
-    assert data[0]['when'] is None
+    assert data[0]['DateIssue'] == '2020-09-01'
+    assert data[0]['DateForecast'] == '2020-09-02'
+    assert data[0]['ReportingArea'] == 'Los Angeles'
+    assert data[0]['StateCode'] == 'CA'
+    assert data[0]['ParameterName'] == 'O3'
+    assert data[0]['AQI'] == 55
+    assert data[0]['Category'] == {'Number': 2, 'Name': 'Moderate'}
+    assert data[0]['ActionDay'] is False
 
-    assert 'zipCode' in data[0]['query']
-    assert data[0]['query']['zipCode'] == '90001'
+    assert data[1]['ParameterName'] == 'PM2.5'
+    assert data[1]['AQI'] == 42
+    assert data[1]['Category'] == {'Number': 1, 'Name': 'Good'}
 
 
 @pytest.mark.asyncio
@@ -28,17 +34,8 @@ async def test_api_forecast_zipcode_distance(mock_airnowapi):
     data = await client.forecast.zipCode(90001, distance=100)
 
     assert isinstance(data, list)
-    assert len(data) == 1
-
-    assert data[0]['type'] == 'forecast'
-    assert data[0]['mode'] == 'zipCode'
-    assert data[0]['when'] is None
-
-    assert 'zipCode' in data[0]['query']
-    assert data[0]['query']['zipCode'] == '90001'
-
-    assert 'distance' in data[0]['query']
-    assert data[0]['query']['distance'] == '100'
+    assert len(data) == 2
+    assert data[0]['ParameterName'] == 'O3'
 
 
 @pytest.mark.asyncio
@@ -47,17 +44,7 @@ async def test_api_forecast_zipcode_date_str(mock_airnowapi):
     data = await client.forecast.zipCode(90001, date='2020-09-01')
 
     assert isinstance(data, list)
-    assert len(data) == 1
-
-    assert data[0]['type'] == 'forecast'
-    assert data[0]['mode'] == 'zipCode'
-    assert data[0]['when'] is None
-
-    assert 'zipCode' in data[0]['query']
-    assert data[0]['query']['zipCode'] == '90001'
-
-    assert 'date' in data[0]['query']
-    assert data[0]['query']['date'] == '2020-09-01'
+    assert len(data) == 2
 
 
 @pytest.mark.asyncio
@@ -69,17 +56,7 @@ async def test_api_forecast_zipcode_date_date(mock_airnowapi):
     )
 
     assert isinstance(data, list)
-    assert len(data) == 1
-
-    assert data[0]['type'] == 'forecast'
-    assert data[0]['mode'] == 'zipCode'
-    assert data[0]['when'] is None
-
-    assert 'zipCode' in data[0]['query']
-    assert data[0]['query']['zipCode'] == '90001'
-
-    assert 'date' in data[0]['query']
-    assert data[0]['query']['date'] == '2020-09-01'
+    assert len(data) == 2
 
 
 @pytest.mark.asyncio
@@ -91,17 +68,7 @@ async def test_api_forecast_zipcode_date_datetime(mock_airnowapi):
     )
 
     assert isinstance(data, list)
-    assert len(data) == 1
-
-    assert data[0]['type'] == 'forecast'
-    assert data[0]['mode'] == 'zipCode'
-    assert data[0]['when'] is None
-
-    assert 'zipCode' in data[0]['query']
-    assert data[0]['query']['zipCode'] == '90001'
-
-    assert 'date' in data[0]['query']
-    assert data[0]['query']['date'] == '2020-09-01'
+    assert len(data) == 2
 
 
 @pytest.mark.asyncio
@@ -110,16 +77,15 @@ async def test_api_forecast_ll(mock_airnowapi):
     data = await client.forecast.latLong(34.053718, -118.244842)
 
     assert isinstance(data, list)
-    assert len(data) == 1
+    assert len(data) == 2
 
-    assert data[0]['type'] == 'forecast'
-    assert data[0]['mode'] == 'latLong'
-    assert data[0]['when'] is None
-
-    assert 'latitude' in data[0]['query']
-    assert data[0]['query']['latitude'] == '34.053718'
-    assert 'longitude' in data[0]['query']
-    assert data[0]['query']['longitude'] == '-118.244842'
+    assert data[0]['DateIssue'] == '2020-09-01'
+    assert data[0]['DateForecast'] == '2020-09-02'
+    assert data[0]['ReportingArea'] == 'Los Angeles'
+    assert data[0]['StateCode'] == 'CA'
+    assert data[0]['ParameterName'] == 'O3'
+    assert data[0]['AQI'] == 55
+    assert data[0]['Category'] == {'Number': 2, 'Name': 'Moderate'}
 
 
 @pytest.mark.asyncio
@@ -131,19 +97,7 @@ async def test_api_forecast_ll_distance(mock_airnowapi):
     )
 
     assert isinstance(data, list)
-    assert len(data) == 1
-
-    assert data[0]['type'] == 'forecast'
-    assert data[0]['mode'] == 'latLong'
-    assert data[0]['when'] is None
-
-    assert 'latitude' in data[0]['query']
-    assert data[0]['query']['latitude'] == '34.053718'
-    assert 'longitude' in data[0]['query']
-    assert data[0]['query']['longitude'] == '-118.244842'
-
-    assert 'distance' in data[0]['query']
-    assert data[0]['query']['distance'] == '120'
+    assert len(data) == 2
 
 
 @pytest.mark.asyncio
@@ -155,19 +109,7 @@ async def test_api_forecast_ll_date_str(mock_airnowapi):
     )
 
     assert isinstance(data, list)
-    assert len(data) == 1
-
-    assert data[0]['type'] == 'forecast'
-    assert data[0]['mode'] == 'latLong'
-    assert data[0]['when'] is None
-
-    assert 'latitude' in data[0]['query']
-    assert data[0]['query']['latitude'] == '34.053718'
-    assert 'longitude' in data[0]['query']
-    assert data[0]['query']['longitude'] == '-118.244842'
-
-    assert 'date' in data[0]['query']
-    assert data[0]['query']['date'] == '2020-09-01'
+    assert len(data) == 2
 
 
 @pytest.mark.asyncio
@@ -179,19 +121,7 @@ async def test_api_forecast_ll_date_date(mock_airnowapi):
     )
 
     assert isinstance(data, list)
-    assert len(data) == 1
-
-    assert data[0]['type'] == 'forecast'
-    assert data[0]['mode'] == 'latLong'
-    assert data[0]['when'] is None
-
-    assert 'latitude' in data[0]['query']
-    assert data[0]['query']['latitude'] == '34.053718'
-    assert 'longitude' in data[0]['query']
-    assert data[0]['query']['longitude'] == '-118.244842'
-
-    assert 'date' in data[0]['query']
-    assert data[0]['query']['date'] == '2020-09-01'
+    assert len(data) == 2
 
 
 @pytest.mark.asyncio
@@ -203,16 +133,4 @@ async def test_api_forecast_ll_date_datetime(mock_airnowapi):
     )
 
     assert isinstance(data, list)
-    assert len(data) == 1
-
-    assert data[0]['type'] == 'forecast'
-    assert data[0]['mode'] == 'latLong'
-    assert data[0]['when'] is None
-
-    assert 'latitude' in data[0]['query']
-    assert data[0]['query']['latitude'] == '34.053718'
-    assert 'longitude' in data[0]['query']
-    assert data[0]['query']['longitude'] == '-118.244842'
-
-    assert 'date' in data[0]['query']
-    assert data[0]['query']['date'] == '2020-09-01'
+    assert len(data) == 2

--- a/tests/test_13_observations.py
+++ b/tests/test_13_observations.py
@@ -11,14 +11,19 @@ async def test_api_observations_zipcode(mock_airnowapi):
     data = await client.observations.zipCode(90001)
 
     assert isinstance(data, list)
-    assert len(data) == 1
+    assert len(data) == 2
 
-    assert data[0]['type'] == 'observation'
-    assert data[0]['mode'] == 'zipCode'
-    assert data[0]['when'] == 'current'
+    assert data[0]['DateObserved'] == '2020-09-01'
+    assert data[0]['HourObserved'] == 15
+    assert data[0]['LocalTimeZone'] == 'PDT'
+    assert data[0]['ReportingArea'] == 'Los Angeles'
+    assert data[0]['ParameterName'] == 'PM2.5'
+    assert data[0]['AQI'] == 55
+    assert data[0]['Category'] == {'Number': 2, 'Name': 'Moderate'}
 
-    assert 'zipCode' in data[0]['query']
-    assert data[0]['query']['zipCode'] == '90001'
+    assert data[1]['ParameterName'] == 'O3'
+    assert data[1]['AQI'] == 42
+    assert data[1]['Category'] == {'Number': 1, 'Name': 'Good'}
 
 
 @pytest.mark.asyncio
@@ -27,17 +32,8 @@ async def test_api_observations_zipcode_distance(mock_airnowapi):
     data = await client.observations.zipCode(90001, distance=100)
 
     assert isinstance(data, list)
-    assert len(data) == 1
-
-    assert data[0]['type'] == 'observation'
-    assert data[0]['mode'] == 'zipCode'
-    assert data[0]['when'] == 'current'
-
-    assert 'zipCode' in data[0]['query']
-    assert data[0]['query']['zipCode'] == '90001'
-
-    assert 'distance' in data[0]['query']
-    assert data[0]['query']['distance'] == '100'
+    assert len(data) == 2
+    assert data[0]['ParameterName'] == 'PM2.5'
 
 
 @pytest.mark.asyncio
@@ -46,16 +42,15 @@ async def test_api_observations_ll(mock_airnowapi):
     data = await client.observations.latLong(34.053718, -118.244842)
 
     assert isinstance(data, list)
-    assert len(data) == 1
+    assert len(data) == 2
 
-    assert data[0]['type'] == 'observation'
-    assert data[0]['mode'] == 'latLong'
-    assert data[0]['when'] == 'current'
-
-    assert 'latitude' in data[0]['query']
-    assert data[0]['query']['latitude'] == '34.053718'
-    assert 'longitude' in data[0]['query']
-    assert data[0]['query']['longitude'] == '-118.244842'
+    assert data[0]['DateObserved'] == '2020-09-01'
+    assert data[0]['HourObserved'] == 15
+    assert data[0]['LocalTimeZone'] == 'PDT'
+    assert data[0]['ReportingArea'] == 'Los Angeles'
+    assert data[0]['ParameterName'] == 'PM2.5'
+    assert data[0]['AQI'] == 55
+    assert data[0]['Category'] == {'Number': 2, 'Name': 'Moderate'}
 
 
 @pytest.mark.asyncio
@@ -67,16 +62,5 @@ async def test_api_observations_ll_distance(mock_airnowapi):
     )
 
     assert isinstance(data, list)
-    assert len(data) == 1
-
-    assert data[0]['type'] == 'observation'
-    assert data[0]['mode'] == 'latLong'
-    assert data[0]['when'] == 'current'
-
-    assert 'latitude' in data[0]['query']
-    assert data[0]['query']['latitude'] == '34.053718'
-    assert 'longitude' in data[0]['query']
-    assert data[0]['query']['longitude'] == '-118.244842'
-
-    assert 'distance' in data[0]['query']
-    assert data[0]['query']['distance'] == '120'
+    assert len(data) == 2
+    assert data[0]['ParameterName'] == 'PM2.5'

--- a/tests/test_13_observations.py
+++ b/tests/test_13_observations.py
@@ -29,7 +29,8 @@ async def test_api_observations_zipcode(mock_airnowapi):
 @pytest.mark.asyncio
 async def test_api_observations_zipcode_distance(mock_airnowapi):
     client = WebServiceAPI(MOCK_API_KEY)
-    data = await client.observations.zipCode(90001, distance=100)
+    with pytest.warns(DeprecationWarning, match='distance parameter is deprecated'):
+        data = await client.observations.zipCode(90001, distance=100)
 
     assert isinstance(data, list)
     assert len(data) == 2
@@ -56,11 +57,37 @@ async def test_api_observations_ll(mock_airnowapi):
 @pytest.mark.asyncio
 async def test_api_observations_ll_distance(mock_airnowapi):
     client = WebServiceAPI(MOCK_API_KEY)
-    data = await client.observations.latLong(
-        34.053718, -118.244842,
-        distance=120
-    )
+    with pytest.warns(DeprecationWarning, match='distance parameter is deprecated'):
+        data = await client.observations.latLong(
+            34.053718, -118.244842,
+            distance=120
+        )
 
     assert isinstance(data, list)
     assert len(data) == 2
     assert data[0]['ParameterName'] == 'PM2.5'
+
+
+@pytest.mark.asyncio
+async def test_api_observations_zipcode_raw_format(mock_airnowapi):
+    client = WebServiceAPI(MOCK_API_KEY, legacy_format=False)
+    data = await client.observations.zipCode(90001)
+
+    assert isinstance(data, list)
+    assert len(data) == 2
+    assert data[0]['parameterName'] == 'PM2.5'
+    assert data[0]['nowcastAQI'] == 55
+    assert data[0]['aqiCategoryName'] == 'Moderate'
+    assert 'DateObserved' not in data[0]
+
+
+@pytest.mark.asyncio
+async def test_api_observations_ll_raw_format(mock_airnowapi):
+    client = WebServiceAPI(MOCK_API_KEY, legacy_format=False)
+    data = await client.observations.latLong(34.053718, -118.244842)
+
+    assert isinstance(data, list)
+    assert len(data) == 2
+    assert data[0]['parameterName'] == 'PM2.5'
+    assert data[0]['nowcastAQI'] == 55
+    assert 'DateObserved' not in data[0]

--- a/tests/test_15_normalization.py
+++ b/tests/test_15_normalization.py
@@ -1,0 +1,122 @@
+'''Tests for response normalization from new API format to legacy format'''
+from pyairnow.observation import _normalize_observation, CATEGORY_NAME_TO_NUMBER
+from pyairnow.forecast import _normalize_forecast
+
+
+class TestObservationNormalization:
+    def test_basic_fields(self):
+        raw = {
+            'dateObserved': '2024-01-15',
+            'hourObserved': '14:00',
+            'localTimeZone': 'PST',
+            'reportingAreaName': 'San Francisco',
+            'parameterName': 'PM2.5',
+            'nowcastAQI': 42,
+            'aqiCategoryName': 'Good',
+        }
+        result = _normalize_observation(raw)
+
+        assert result['DateObserved'] == '2024-01-15'
+        assert result['HourObserved'] == 14
+        assert result['LocalTimeZone'] == 'PST'
+        assert result['ReportingArea'] == 'San Francisco'
+        assert result['ParameterName'] == 'PM2.5'
+        assert result['AQI'] == 42
+        assert result['Category'] == {'Number': 1, 'Name': 'Good'}
+
+    def test_ozone_renamed_to_o3(self):
+        raw = {
+            'parameterName': 'OZONE',
+            'nowcastAQI': 30,
+            'aqiCategoryName': 'Good',
+        }
+        result = _normalize_observation(raw)
+        assert result['ParameterName'] == 'O3'
+
+    def test_pm10_unchanged(self):
+        raw = {'parameterName': 'PM10', 'nowcastAQI': 20, 'aqiCategoryName': 'Good'}
+        result = _normalize_observation(raw)
+        assert result['ParameterName'] == 'PM10'
+
+    def test_hour_string_parsed(self):
+        raw = {'hourObserved': '09:00', 'aqiCategoryName': ''}
+        result = _normalize_observation(raw)
+        assert result['HourObserved'] == 9
+
+    def test_hour_integer_passthrough(self):
+        raw = {'hourObserved': 15, 'aqiCategoryName': ''}
+        result = _normalize_observation(raw)
+        assert result['HourObserved'] == 15
+
+    def test_all_category_mappings(self):
+        for name, expected_number in CATEGORY_NAME_TO_NUMBER.items():
+            raw = {'aqiCategoryName': name}
+            result = _normalize_observation(raw)
+            assert result['Category']['Number'] == expected_number
+            assert result['Category']['Name'] == name
+
+    def test_unknown_category_defaults_to_zero(self):
+        raw = {'aqiCategoryName': 'Unknown Category'}
+        result = _normalize_observation(raw)
+        assert result['Category']['Number'] == 0
+
+    def test_missing_fields_default_gracefully(self):
+        result = _normalize_observation({})
+        assert result['DateObserved'] == ''
+        assert result['HourObserved'] == 0
+        assert result['LocalTimeZone'] == ''
+        assert result['ReportingArea'] == ''
+        assert result['StateCode'] == ''
+        assert result['Latitude'] is None
+        assert result['Longitude'] is None
+        assert result['ParameterName'] == ''
+        assert result['AQI'] == -1
+
+
+class TestForecastNormalization:
+    def test_basic_fields(self):
+        raw = {
+            'dateIssue': '2024-01-15',
+            'dateValid': '2024-01-16',
+            'reportingArea': 'Los Angeles',
+            'stateCode': 'CA',
+            'parameterName': 'PM2.5',
+            'aqi': 55,
+            'categoryNumber': 2,
+            'categoryName': 'Moderate',
+            'actionDay': True,
+            'discussion': 'Expect moderate air quality',
+        }
+        result = _normalize_forecast(raw)
+
+        assert result['DateIssue'] == '2024-01-15'
+        assert result['DateForecast'] == '2024-01-16'
+        assert result['ReportingArea'] == 'Los Angeles'
+        assert result['StateCode'] == 'CA'
+        assert result['ParameterName'] == 'PM2.5'
+        assert result['AQI'] == 55
+        assert result['Category'] == {'Number': 2, 'Name': 'Moderate'}
+        assert result['ActionDay'] is True
+        assert result['Discussion'] == 'Expect moderate air quality'
+
+    def test_ozone_renamed_to_o3(self):
+        raw = {
+            'parameterName': 'OZONE',
+            'aqi': 30,
+            'categoryNumber': 1,
+            'categoryName': 'Good',
+        }
+        result = _normalize_forecast(raw)
+        assert result['ParameterName'] == 'O3'
+
+    def test_missing_fields_default_gracefully(self):
+        result = _normalize_forecast({})
+        assert result['DateIssue'] == ''
+        assert result['DateForecast'] == ''
+        assert result['ReportingArea'] == ''
+        assert result['StateCode'] == ''
+        assert result['ParameterName'] == ''
+        assert result['AQI'] == -1
+        assert result['Category'] == {'Number': 0, 'Name': ''}
+        assert result['ActionDay'] is False
+        assert result['Discussion'] == ''


### PR DESCRIPTION
I handed Claude the https://docs.airnowapi.org/docs/AirNowAPIUpdates2026June.pdf file (attached for posterity - 
[AirNowAPIUpdates2026June.pdf](https://github.com/user-attachments/files/29186722/AirNowAPIUpdates2026June.pdf)) and had it go to work. It's been working great locally for a few days with zero changes to HA. Below is what Claude put together. Feel free to steal, ignore, or cherry pick. It addresses #17 

---

Six AirNow API endpoints are being retired on September 30, 2026. This updates pyairnow to use the replacement endpoints and normalizes the new response format back to the legacy format for backward compatibility.

Endpoint changes:
- observations: aq/observation/{zipCode,latLong}/current -> aq/observation/current/ziplatlong
- forecasts: aq/forecast/{zipCode,latLong} -> aq/forecast/current

Response normalization handles:
- Field name changes (camelCase -> PascalCase)
- OZONE -> O3 parameter name mapping
- nowcastAQI -> AQI
- Flat aqiCategoryName -> nested Category object
- String hourObserved ("15:00") -> integer (15)